### PR TITLE
feat: add mirroring to github packages

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -1,0 +1,12 @@
+name: "Publish Package to GitHub"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-js-gh:
+    name: "Publish Package"
+    uses: bankrate/finserv-reusable-gha/.github/workflows/publish-js-gh.yml@main
+    with:
+      node-version: '14.x'


### PR DESCRIPTION
## Overview

This PR mirrors this package into our new preferred package manager - GitHub Packages 🎉 .

## Checklist

Here are some things you might check:

- [ ] Is the Node version specified correct?
- [ ] Is the context that the build and publish command is run in correct?
- [ ] Are the correct files being generated and published?
- [ ] Are there additional steps that are needed in this build process?

> **Warning**
> This PR may not work if this relies on another package that is only in Artifactory

## Resources

- [GitHub Actions workflow being used](https://github.com/bankrate/finserv-reusable-gha/blob/main/.github/workflows/publish-js-gh.yml) (for instance if you wanted to copy and make some changes)
- [Current Package migration status](https://docs.google.com/spreadsheets/d/1lCggd3DdknE85_eVa6x2TZRSRF2zHtFoCFifijFivzo/edit#gid=1460997285)
