### PR TITLE
Update GH publish to do the same build & publish that Circle does

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -18,6 +18,7 @@ jobs:
           node-version: "18.x"
           registry-url: "https://npm.pkg.github.com"
       - run: npm ci
-      - run: npm publish
+      - run: npm run build
+      - run: npm run publish-package none
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bankrate/parse-address",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "US Street Address Parser",
   "main": "dist/parser.js",
   "scripts": {


### PR DESCRIPTION
Matches the fix that worked for the salvia-scss library as well.

Package downloads just fine, but when you try to compile it complains it can't find it.
Eventually I pulled it down both ways & saw that the Artifactory version included a dist folder, while the GitHub version did not.